### PR TITLE
update SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -10,6 +10,8 @@
 - `Ubuntu 16.04` or `Ubuntu 18.04` (though other Linux distros are probably supported, more info coming soon).
 - Docker
 - Docker-Compose
+- Yarn
+- Node.js
 
 ### Setup
 


### PR DESCRIPTION
Added Yarn & Node.js to requirements list.

Note : It's possible they were/are already present in the environment that enigma tests in when they are not actually installed on the default ubuntu image for 18.04 that I'm using.